### PR TITLE
Remove `maxBodySize` parameter from webapp nginx template

### DIFF
--- a/templates/webapp/deployment.yaml
+++ b/templates/webapp/deployment.yaml
@@ -58,10 +58,6 @@ spec:
           image: quay.io/ukhomeofficedigital/nginx-proxy:v3
           {{#nginx.length}}
           env:
-            {{#maxBodySize}}
-            - name: CLIENT_MAX_BODY_SIZE
-              value: '{{{maxBodySize}}}'
-            {{/maxBodySize}}
             {{#nginx}}
             - name: {{{name}}}
               {{^secret}}


### PR DESCRIPTION
The correct values are configured directly as an environment variable in the config files, and so having this was causing it to be defined twice, and the first-defined (and incorrect) value to be used.