### PR TITLE
Add name labels to job deployment templates

### DIFF
--- a/templates/cronjob/deployment.yaml
+++ b/templates/cronjob/deployment.yaml
@@ -8,6 +8,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            name: {{{name}}}
         spec:
           restartPolicy: Never
           containers:

--- a/templates/job/deployment.yaml
+++ b/templates/job/deployment.yaml
@@ -7,6 +7,9 @@ spec:
   completions: 1
   backoffLimit: 0
   template:
+    metadata:
+      labels:
+        name: {{{name}}}
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
This means they can be targetted by ingress network policies to allow them to access other pods.