### PR TITLE
replace old tokens, update npmrc

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -6,28 +6,28 @@ steps:
   - name: install
     image: node:12
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
     commands:
       - npm ci
   - name: test
     image: node:12
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
     commands:
       - npm test
   - name: publish
     image: node:12
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
     commands:
       - npm publish
     when:

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
-@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
+@ukhomeoffice:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
 
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:username=${NPM_AUTH_USERNAME}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_password=${NPM_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:email=leonard.martin@digital.homeoffice.gov.uk
+@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
+//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_authToken=${ART_AUTH_TOKEN}
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true


### PR DESCRIPTION
Lenny's creds are being used to pull from and publish to internal npm in https://artifactory.digital.homeoffice.gov.uk/
But he's been offboarded

This changes to using a long lived token for accessing internal artifactory and also adds in tokens for if we switch to Github workflows in the future